### PR TITLE
Test folder needs to be a module

### DIFF
--- a/eng-debugging/hello_world_python/README.md
+++ b/eng-debugging/hello_world_python/README.md
@@ -1,13 +1,13 @@
 ### Setup
 1. If you don't have Python 3 installed, run `brew install python` (for Mac)
 2. Run `pip3 install pytest` if you don't have pytest already installed.
-3. Run `PYTHONPATH=. pytest test -vv` to run all tests
-4. Run `PYTHONPATH=. pytest test -vv -k 'test_case_one'` to run just the first test
+3. Run `PYTHONPATH=. pytest -vv` to run all tests
+4. Run `PYTHONPATH=. pytest -vv -k 'test_case_one'` to run just the first test
 
 **Windows instructions**
 If using the Command Prompt (CMD), then set the PYTHONPATH with `set PYTHONPATH=%PYTHONPATH%;.`
 If using Powershell, then set the PYTHONPATH with `$env:PYTHONPATH = "."`
-After setting the path, run tests with `pytest test -vv`
+After setting the path, run tests with `pytest -vv`
 
 ## Tested on
 Python 3.7.4


### PR DESCRIPTION
There needs to be an `__init__.py` inside the `test` folder to mark the folder as a module, otherwise the relative import will fail with the following message:

```
Traceback:
/usr/local/lib/python3.9/site-packages/_pytest/python.py:578: in _importtestmodule
    mod = import_path(self.fspath, mode=importmode)
/usr/local/lib/python3.9/site-packages/_pytest/pathlib.py:531: in import_path
    importlib.import_module(module_name)
/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:986: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:680: in _load_unlocked
    ???
/usr/local/lib/python3.9/site-packages/_pytest/assertion/rewrite.py:170: in exec_module
    exec(co, module.__dict__)
test/hello_world_test.py:3: in <module>
    from lib.index import HelloWorld
E   ModuleNotFoundError: No module named 'lib'
```

Also, `pytest` needs to be run with the parent directory, not from the `test` subfolder, and I've updated the README to reflect this.