### PR TITLE
Fix python project structure and readme

### DIFF
--- a/eng-debugging/hello_world_python/README.md
+++ b/eng-debugging/hello_world_python/README.md
@@ -1,13 +1,10 @@
 ### Setup
+
 1. If you don't have Python 3 installed, run `brew install python` (for Mac)
 2. Run `pip3 install pytest` if you don't have pytest already installed.
-3. Run `PYTHONPATH=. pytest test -vv` to run all tests
-4. Run `PYTHONPATH=. pytest test -vv -k 'test_case_one'` to run just the first test
-
-**Windows instructions**
-If using the Command Prompt (CMD), then set the PYTHONPATH with `set PYTHONPATH=%PYTHONPATH%;.`
-If using Powershell, then set the PYTHONPATH with `$env:PYTHONPATH = "."`
-After setting the path, run tests with `pytest test -vv`
+3. Run `pytest` to run all tests
+4. Run `pytest -k 'test_case_one'` to run just the first test
 
 ## Tested on
+
 Python 3.7.4

--- a/eng-debugging/hello_world_python/pytest.ini
+++ b/eng-debugging/hello_world_python/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -vv
+testpaths =
+    test


### PR DESCRIPTION
@billmei noted in #2 that the test directory needs to include an `__init__.py` file. After we do that, we actually don't need `PYTHONPATH` at all, so I updated the readme accordingly. I also added a `pytest.ini` to make `-vv` default.